### PR TITLE
Some fixes to run CL-SAT on Mac OS X (SBCL 1.5.2)

### DIFF
--- a/cl-sat.asd
+++ b/cl-sat.asd
@@ -2,12 +2,14 @@
 ;;;; In order to regenerate it, run update-asdf from shell (see https://github.com/phoe-krk/asd-generator)
 ;;;; For those who do not have update-asdf, run `ros install asd-generator` (if you have roswell installed)
 ;;;; There are also an interface available from lisp: (asd-generator:regen &key im-sure)
+
 (defsystem cl-sat
  :version "0.1"
  :author "Masataro Asai"
  :mailto "guicho2.71828@gmail.com"
  :license "LLGPL"
- :depends-on (:trivia :alexandria :iterate)
+ :depends-on (:trivia :alexandria :iterate
+              :trivial-features)
  :serial t
  :components ((:file "src/0-package")
               (:file "src/1-parse")

--- a/src/0-package.lisp
+++ b/src/0-package.lisp
@@ -4,6 +4,7 @@
 |#
 
 (in-package :cl-user)
+
 (defpackage cl-sat
   (:nicknames :sat)
   (:use :cl :trivia :alexandria :iterate)
@@ -13,7 +14,7 @@
    #:print-cnf
    #:with-temp
    #:*instance*
-   #:variables
+   #:sat-instance-variables
    #:to-nnf
    #:to-cnf
    #:to-cnf-naive
@@ -21,8 +22,6 @@
    #:symbolicate-form
    #:*verbosity*
    #:parse-dimacs-output))
+
 (in-package :cl-sat)
-
-
-
 

--- a/src/1-util.lisp
+++ b/src/1-util.lisp
@@ -5,12 +5,13 @@
 Most arguments are analogous to mktemp.
 When DIRECTORY is non-nil, creates a directory instead.
 When DEBUG is non-nil, it does not remove the directory so that you can investigate what happened inside the directory."
-  `(let ((,var (uiop:run-program (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir ,directory ,template)
-                                 :output '(:string :stripped t))))
+  (declare (ignorable template tmpdir))
+  `(let ((,var (uiop:run-program
+		 #-darwin (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir ,directory ,template)
+		 #+darwin (if ,directory "mktemp -d" "mktemp")
+		 :output '(:string :stripped t))))
      (unwind-protect
          (progn ,@body)
        (if ,debug
            (format t "~&not removing ~a for debugging" ,var)
            (uiop:run-program (format nil "rm -rf ~a" (namestring ,var)) :ignore-error-status t)))))
-
-

--- a/src/1-util.lisp
+++ b/src/1-util.lisp
@@ -7,8 +7,10 @@ When DIRECTORY is non-nil, creates a directory instead.
 When DEBUG is non-nil, it does not remove the directory so that you can investigate what happened inside the directory."
   (declare (ignorable template tmpdir))
   `(let ((,var (uiop:run-program
-		 #-darwin (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir ,directory ,template)
-		 #+darwin (if ,directory "mktemp -d" "mktemp")
+		 #-:BSD (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir
+				    ,directory ,template)
+		 ;; BSD also includes Darwin (Mac OS X) (c.f. trivial-features's SPEC.md)
+		 #+:BSD (if ,directory "mktemp -d" "mktemp")
 		 :output '(:string :stripped t))))
      (unwind-protect
          (progn ,@body)

--- a/src/1-util.lisp
+++ b/src/1-util.lisp
@@ -7,10 +7,10 @@ When DIRECTORY is non-nil, creates a directory instead.
 When DEBUG is non-nil, it does not remove the directory so that you can investigate what happened inside the directory."
   (declare (ignorable template tmpdir))
   `(let ((,var (uiop:run-program
-		 #-:BSD (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir
+		 #-BSD (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir
 				    ,directory ,template)
 		 ;; BSD also includes Darwin (Mac OS X) (c.f. trivial-features's SPEC.md)
-		 #+:BSD (if ,directory "mktemp -d" "mktemp")
+		 #+BSD (if ,directory "mktemp -d" "mktemp")
 		 :output '(:string :stripped t))))
      (unwind-protect
          (progn ,@body)

--- a/src/2-class.lisp
+++ b/src/2-class.lisp
@@ -31,8 +31,7 @@
          solver
          args))
 
-
-(defun variables (instance)
+(defmethod sat-instance-variables ((instance sat-instance))
   (with-slots (%variables) instance
     (if (slot-boundp instance '%variables)
         %variables
@@ -43,4 +42,3 @@
                  (flatten (cnf instance))
                  '(and or not)))
                'simple-vector)))))
-


### PR DESCRIPTION
Hi,

thanks for your work. I'm on Mac OS X (10.11), and with some basic fixes I managed to run your packages (with Minisat) on SBCL 1.5.2. Here are some outputs:

```
* (cl-sat:solve '(and (or a b) (or a !b c)) :minisat)
; cd /var/folders/3p/chkkd6m17sn2ypz5rdnlphh40000gn/T/tmp.Qz25DFd7; minisat  /var/folders/3p/chkkd6m17sn2ypz5rdnlphh40000gn/T/tmp.rsI3G5KD result============================[ Problem Statistics ]=============================
|                                                                             |
|  Number of variables:             6                                         |
|  Number of clauses:               2                                         |
|  Parse time:                   0.00 s                                       |
|  Eliminated clauses:           0.00 Mb                                      |
|  Simplification time:          0.00 s                                       |
|                                                                             |
============================[ Search Statistics ]==============================
| Conflicts |          ORIGINAL         |          LEARNT          | Progress |
|           |    Vars  Clauses Literals |    Limit  Clauses Lit/Cl |          |
===============================================================================
===============================================================================
restarts              : 1
conflicts             : 0              (0 /sec)
decisions             : 1              (0.00 % random) (1003 /sec)
propagations          : 3              (3009 /sec)
conflict literals     : 0              ( nan % deleted)
Memory used           : 0.10 MB
CPU time              : 0.000997 s

SATISFIABLE
(C B CL-SAT.AUX-VARIABLES::AUX2 CL-SAT.AUX-VARIABLES::AUX1
 CL-SAT.AUX-VARIABLES::AUX0)
T
T

* (cl-sat:solve '(and (or a b) (or a !b c)) :competition :year 2018 :track "main_and_glucose_hack" :name "Lingeling")
Archive:  Lingeling.zip
  inflating: Lingeling/starexec_build  
  inflating: Lingeling/build/build.sh  
  inflating: Lingeling/bin/starexec_run_default  
  inflating: Lingeling/archives/lingeling-sc18-80c732d-180412.tar.gz  
  inflating: Lingeling/archives/druplig-009.zip  
Archive:  ../archives/druplig-009.zip
   creating: druplig-009/
  inflating: druplig-009/druplig.h   
  inflating: druplig-009/druplig.c   
  inflating: druplig-009/testdruplig.c  
 extracting: druplig-009/VERSION     
  inflating: druplig-009/makefile.in  
   creating: druplig-009/log/
 extracting: druplig-009/log/README  
  inflating: druplig-009/LICENSE     
  inflating: druplig-009/configure.sh  
  inflating: druplig-009/README      
gcc -Wall -O3 -DNDEBUG -DNSIG -DVERSION=\"009\"
gcc -Wall -O3 -DNDEBUG -DNSIG -DVERSION=\"009\" -c druplig.c
ar rc libdruplig.a druplig.o
ranlib libdruplig.a
found and using ../druplig
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -c lglmain.c
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -c lglib.c
rm -f lglcflags.h
echo '#define LGL_CC "Apple LLVM version 8.0.0 (clang-800.0.42.1)"' >> lglcflags.h
echo '#define LGL_CFLAGS "-Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA"' >> lglcflags.h
rm -f lglcfg.h
./mkconfig.sh > lglcfg.h
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -c lglbnr.c
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -c lgldimacs.c
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -c lglopts.c
ar rc liblgl.a lglib.o lglbnr.o lgldimacs.o lglopts.o 
ranlib liblgl.a
gcc -Wall -O3 -I../druplig -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLYALSAT -DNLGLFILES -DNLGLDEMA -o lingeling lglmain.o -L. -llgl -lm -L../druplig -ldruplig
; cd /Users/binghe/Lisp/packages/cl-sat/solvers/2018/main_and_glucose_hack/Lingeling/bin/ ; bash /Users/binghe/Lisp/packages/cl-sat/solvers/2018/main_and_glucose_hack/Lingeling/bin/starexec_run_default /var/folders/3p/chkkd6m17sn2ypz5rdnlphh40000gn/T/tmp.dLuOTEUn /var/folders/3p/chkkd6m17sn2ypz5rdnlphh40000gn/T/tmp.1hzEzUA7
(C B A)
T
T
NIL
```

The main problem is, the command `mktemp` has very different options between Mac OS and Linux. Here the created file or directory is always at some places under `/var`, so basically it only matters to choose what to create (file or directory).

I temporarily recovered your symbol name change from `sat-instance-variables` to `variables` (and changed it into a class method). And I'll send you another small PR on `cl-sat.minisat` side, as the type of this `sat-instance-variables` has changed from list to vector.

But, overall speaking, it really works! That's excellent, now I can implement my SAT-based search tool in Common Lisp.

Regards,

Chun Tian

