### PR TITLE
Fix mktemp call to work inside Portacle.

### DIFF
--- a/src/1-util.lisp
+++ b/src/1-util.lisp
@@ -1,32 +1,68 @@
 (in-package :cl-sat)
 
-(defmacro with-temp ((var &key directory template (tmpdir "/tmp/") debug) &body body)
+(defmacro with-temp ((var &key directory (template "tmp.XXXXXXX") (tmpdir "/tmp/") debug) &body body)
   "Create a temporary file, then remove the file by unwind-protect.
 Most arguments are analogous to mktemp.
+TEMPLATE should be a string that ends with one or more X's, these X's will be replaced by random characters.
 When DIRECTORY is non-nil, creates a directory instead.
-When DEBUG is non-nil, it does not remove the directory so that you can investigate what happened inside the directory."
+When DEBUG is non-nil, it does not remove the directory so that you can investigate what happened inside the directory.
+An error of type file-error is signalled if a unique file name can't be generated after a number of attempts."
   (declare (ignorable template tmpdir))
-  `(let ((,var (uiop:run-program
-                (cond
-                  ((member :portacle *features*)
-                   ;; The Portacle development environment comes with BusyBox, which overrides
-                   ;; the mktemp command with a simpler version.
-                   ;; See: 1) https://github.com/portacle/portacle/issues/129
-                   ;;      2) https://github.com/guicho271828/cl-sat.minisat/issues/2
-                   (format nil "mktemp ~@[-d~*~] -p ~a ~a" ,directory ,tmpdir ,template))
-                  ((member :bsd *features*)
-                   ;; BSD also includes Darwin (Mac OS X) (c.f. trivial-features's SPEC.md)
-                   (if ,directory "mktemp -d" "mktemp"))
-                  (t
-                   (format nil "mktemp --tmpdir='~a' ~@[-d~*~] ~a" ,tmpdir
-                           ,directory ,template)))
-		 :output '(:string :stripped t))))
+  `(let ((,var
+           ,(let* ((template-without-xs (string-right-trim "X" template)))
+              (attempt-create-temp directory
+                                   tmpdir
+                                   template-without-xs
+                                   (- (length template) (length template-without-xs))
+                                   3))))
      (unwind-protect
-         (progn ,@body)
+          (progn ,@body)
        (if ,debug
            (format t "~&not removing ~a for debugging" ,var)
            (uiop:run-program (format nil "rm -rf ~a" (namestring ,var)) :ignore-error-status t)))))
 
+(defun attempt-create-temp (directory base-dir name-prefix random-string-size attempts)
+  "Creates a file/directory in BASE-DIR with NAME-PREFIX as a prefix of the name and RANDOM-STRING-SIZE
+   random base62 characters at the end.
+   Returns the name of the created file.
+   Signals an error if it can't generate a unique name after ATTEMPTS attempts."
+  (if (<= attempts 0)
+      (error "Couldn't create a unique temp file/folder.")
+      (let ((path (merge-pathnames (let ((name (generate-temp-name name-prefix random-string-size)))
+                                     (if directory
+                                         (make-pathname :directory `(:relative ,name))
+                                         (uiop:parse-unix-namestring name)))
+                                   (uiop:parse-unix-namestring base-dir))))
+        (if (create-nonexisting directory path)
+            (namestring path)
+            (attempt-create-temp directory base-dir name-prefix random-string-size (1- attempts))))))
+
+(defun generate-temp-name (name-prefix random-string-size)
+  "Generates a random name for a temp file/directory.
+   NAME-PREFIX is the prefix of the name, after which RANDOM-STRING-SIZE random characters are added. "
+  (concatenate 'string name-prefix (random-base62 random-string-size)))
+
+(defun random-base62 (n)
+  "Returns a random base62 string with n characters."
+  (let ((table "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
+    (coerce (loop repeat n collect (aref table (random (length table))))
+            'string)))
+
+(defun create-nonexisting (directory path)
+  "Attempts to create a file/directory, returns NIL if it exists already and T otherwise."
+  (handler-case
+      (if directory
+          (multiple-value-bind (_ was-nonexisting) (ensure-directories-exist path)
+            (declare (ignore _))
+            was-nonexisting)
+          (progn
+            (open path
+                  :direction :io
+                  :if-exists :error)
+            t))
+    (file-error (_)
+      (declare (ignore _))
+      nil)))
 
 (defun format1 (stream format-control first-arg &rest more-args)
   (apply #'format stream format-control first-arg more-args)


### PR DESCRIPTION
Portacle ships with BusyBox, which overrides several
common *nix commands with simpler versions, including
mktemp. This commit adds a check for Portacle and
adjusts the call to mktemp appropriately.

Tested by running `with-temp` and `cl-sat.minisat:solve`
inside Portacle, and they worked. Before, they threw an
error due to invalid call to mktemp.

It still won't work on all systems. That would require either
reviewing all versions of mktemp and adding further checks
to `with-temp`, or restricting `with-temp` to use only commands
defined by POSIX.

As per this issue: https://github.com/guicho271828/cl-sat.minisat/issues/2