### PR TITLE
Remove sat-instance initargs from cli options

### DIFF
--- a/src/2-class.lisp
+++ b/src/2-class.lisp
@@ -20,6 +20,11 @@
 (defvar *instance*)
 
 (defmethod solve ((*instance* sat-instance) solver &rest args &key debug &allow-other-keys)
+  ;; Remove sat-instance initargs so they aren't passed to command line
+  (remf args :form)
+  (remf args :cnf)
+  (remf args :converter)
+
   (with-temp (tmp :template "cnf.XXXXXXX" :debug debug)
     (with-output-to-file (s tmp :if-exists :supersede)
       (print-cnf *instance* s))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -198,5 +198,6 @@
   (finishes (print-cnf (make-instance 'sat-instance :form '(not (or a b)))))
   (finishes (print-cnf (make-instance 'sat-instance :form '(and a !a)))))
 
-
+(test converter
+  (is (solve '(and a (not a)) :minisat :converter (constantly '(and a)))))
 


### PR DESCRIPTION
Right now, passing for example the :converter option causes minisat to fail because it tries to pass it as a command line argument to minisat.